### PR TITLE
Fix `dot notation for nested hash lookups' example

### DIFF
--- a/index.rkt
+++ b/index.rkt
@@ -1212,7 +1212,8 @@ messages when used in error. Let's try to do that here.
     [(_ chain)
      #'(hash.refs chain #f)]
     [(_ chain default)
-     (raise-syntax-error #f "Expected hash.key0[.key1 ...] [default]" stx #'chain)
+     (unless (identifier? #'chain)
+       (raise-syntax-error #f "Expected hash.key0[.key1 ...] [default]" stx #'chain))
      (let* ([chain-str (symbol->string (syntax->datum #'chain))]
             [ids (for/list ([str (in-list (regexp-split #rx"\\." chain-str))])
                    (format-id #'chain "~a" str))])


### PR DESCRIPTION
The previous snippet had a guard of "fender" clause that always resulted in an error, even on valid calls. The fixed snippet performs a check and only errors in bad cases.