### PR TITLE
fix function name in margin note

### DIFF
--- a/index.rkt
+++ b/index.rkt
@@ -369,7 +369,7 @@ compiler, and @italic{that} syntax is evaluated:
 (values "i" "am" "backwards")
 ]
 
-@margin-note{The first argument of @racket[syntax->datum] contains the lexical
+@margin-note{The first argument of @racket[datum->syntax] contains the lexical
 context information that we want to associate with the @racket[syntax]
 outputted by the transformer. If the first argument is set to @racket[#f] then
 no lexical context will be associated.}


### PR DESCRIPTION
syntax->datum was used, but I believe datum->syntax was meant