### PR TITLE
Fix typos

### DIFF
--- a/index.rkt
+++ b/index.rkt
@@ -336,7 +336,7 @@ result to evaluate nicely.  Try
 (reverse-me "backwards" "am" "i" values)
 ]
 
-Understand Yoda, can we. Great, but how does this work?
+Understand Yoda, we can. Great, but how does this work?
 
 First we take the input syntax, and give it to
 @racket[syntax->datum]. This converts the syntax into a plain old
@@ -747,7 +747,7 @@ size" template. Let's try that:
            body0 body ...))]))
 ]
 
-No more error---good! Let's try to use it:
+No more errors---good! Let's try to use it:
 
 @i[
 (hyphen-define/wrong1.1 foo bar () #t)
@@ -965,7 +965,7 @@ back.
 
 The first argument of @racket[format-id], @racket[lctx], is the
 lexical context of the identifier that will be created. You almost
-never want to supply @racket[stx] --- the overall chunk of syntax that
+never want to supply @racket[stx]---the overall chunk of syntax that
 the macro transforms. Instead you want to supply some more-specific
 bit of syntax, such as an identifier that the user has provided to the
 macro. In this example, we're using @racket[#'a]. The resulting

--- a/index.rkt
+++ b/index.rkt
@@ -211,10 +211,10 @@ syntax. Everything we do with macros, will be built on top of this
 basic idea. It's not magic.
 
 Speaking of shorthand, there is also a shorthand for @racket[syntax],
-which is @tt{#'}:
+which is @literal{#'}:
 
-@margin-note{@tt{#'} is short for  @racket[syntax] much like
-@tt{'} is short for @racket[quote].}
+@margin-note{@literal{#'} is short for  @racket[syntax] much like
+@literal{'} is short for @racket[quote].}
 
 @i[
 (define-syntax (quoted-foo stx)
@@ -222,7 +222,7 @@ which is @tt{#'}:
 (quoted-foo)
 ]
 
-We'll use the @tt{#'} shorthand from now on.
+We'll use the @literal{#'} shorthand from now on.
 
 Of course, we can emit syntax that is more interesting than a
 string literal. How about returning @racket[(displayln "hi")]?
@@ -734,7 +734,7 @@ work it out.  The "template" the error message refers to is the
 
 In fact, @racket[syntax-case] can have as many templates as you
 want. The obvious, required template is the final expression supplying
-the output syntax. But you can use @racket[syntax] (a.k.a. @tt{#'}) on a
+the output syntax. But you can use @racket[syntax] (a.k.a. @literal{#'}) on a
 pattern variable. This makes another template, albeit a small, "fun
 size" template. Let's try that:
 
@@ -1011,7 +1011,7 @@ To review:
 @itemize[
 
   @item{You can't use a pattern variable outside of a template. But
-you can use @racket[syntax] or @tt{#'} on a pattern variable to make
+you can use @racket[syntax] or @literal{#'} on a pattern variable to make
 an ad hoc, "fun size" template.}
 
   @item{If you want to munge pattern variables for use in the


### PR DESCRIPTION
- Using `@tt{#'}` improperly renders as `#’`—number sign, right single quote (U+2019), instead of `#'`—number sign, typewriter apostrophe (U+0027). Using `@literal{#'}` shows the correct character.

- Yoda’s word order is verb-object-subject (VOS). In English, one would usually say “I must try that.” Yoda would say “Try that, I must.” In the correction, we’d use “Understand Yoda, we can” because “Understand Yoda, can we” is an interrogative statement.

- The other corrections are about spacing and minor grammatical errors.