### PR TITLE
Typo: (- 1 x) -> (- x 1)

### DIFF
--- a/index.rkt
+++ b/index.rkt
@@ -1477,9 +1477,9 @@ The splicing variation is more convenient than the usual way:
 (define-values (inc dec get)
   (let ([x 0])
     (values (lambda ()  ;inc
-              (set! x (+ 1 x)))
+              (set! x (+ x 1)))
             (lambda ()  ;dec
-              (set! x (- 1 x)))
+              (set! x (- x 1)))
             (lambda ()  ;get
               x))))
 )


### PR DESCRIPTION
I also switched (+ 1 x) to (+ x 1) for symmetry with the other example.